### PR TITLE
Add custom idle time setting + skilling cooldown check

### DIFF
--- a/src/main/java/com/distractionreducer/DistractionReducerConfig.java
+++ b/src/main/java/com/distractionreducer/DistractionReducerConfig.java
@@ -5,6 +5,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
 
 import java.awt.Color;
 
@@ -23,6 +24,13 @@ public interface DistractionReducerConfig extends Config {
             position = 1
     )
     String colorPicker = "colorPicker";
+
+    @ConfigSection(
+            name = "Custom",
+            description = "Custom configuration options apart from Toggles",
+            position = 2
+    )
+    String customSetting = "customSetting";
 
     @ConfigItem(
             keyName = "woodcutting",
@@ -113,5 +121,16 @@ public interface DistractionReducerConfig extends Config {
     )
     default Color overlayColor() {
         return new Color(0, 0, 0, 180);
+    }
+
+    @ConfigItem(
+            keyName = "customIdleTime",
+            name = "Idle Time",
+            description = "Configures the amount of time idle (ticks) before overlay is removed.",
+            section = customSetting
+    )
+    @Range(min = 0)
+    default int customIdleTime() {
+        return 4;
     }
 }

--- a/src/main/java/com/distractionreducer/DistractionReducerPlugin.java
+++ b/src/main/java/com/distractionreducer/DistractionReducerPlugin.java
@@ -38,7 +38,8 @@ public class DistractionReducerPlugin extends Plugin {
     private DistractionReducerOverlay distractionReducerOverlay;
 
     private int idleTicks = 0;
-    private static final int MAX_IDLE_TICKS = 2;
+    private static int skillingCooldownTicks = 0;
+    private static final int SKILLING_COOLDOWN_TICKS = 4;
 
     private static final Set<Integer> WOODCUTTING_ANIMATION_IDS = Set.of(
             AnimationID.WOODCUTTING_BRONZE, AnimationID.WOODCUTTING_IRON, AnimationID.WOODCUTTING_STEEL,
@@ -146,11 +147,17 @@ public class DistractionReducerPlugin extends Plugin {
             idleTicks = 0;
         }
 
+        if (isSkilling()) {
+            skillingCooldownTicks = SKILLING_COOLDOWN_TICKS;
+        } else {
+            skillingCooldownTicks--;
+        }
+
         updateOverlayVisibility();
     }
 
     private void updateOverlayVisibility() {
-        boolean shouldRenderOverlay = isSkilling() && (idleTicks < MAX_IDLE_TICKS);
+        boolean shouldRenderOverlay = (skillingCooldownTicks > 0) && (idleTicks < config.customIdleTime());
         distractionReducerOverlay.setRenderOverlay(shouldRenderOverlay);
         log.debug("Overlay visibility updated. Rendering: {}", shouldRenderOverlay);
     }


### PR DESCRIPTION
# Description
* Added customIdleTime configuration option to the plugin. This allows users to tweak the amount of time their specific skilling task requires without any overhead from developer to figure this out. Changed default to "4" to function correctly with Amethyst mining out of the box.
* Added "skillingCooldownTicks", this is defaulting to 4 ticks. This means a player after being  detected as skilling will be considered to be skilling for a 4 tick window.  This will stop any flickering of the overlay if tasks have 1-3 ticks of idle time in between animations.

# Comments
Just a suggestion of features if you have better means of implementation / naming by all means close this. Was having issues with Amethyst mining where the player sometimes will completely stop doing any mining animation with pickaxe and for that moment the overlay will disable and flicker.

Was testing for ~an hour and 4 ticks seems to be what is required to stop the flickering at Amethyst for the idle timing. I determined 3 ticks for the skilling cooldown.