### PR TITLE
feat: Add hunter (maniacal monkeys) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://github.com/user-attachments/assets/3c1d7267-9103-41e2-9f6a-79cfa498e330
   - Fletching
   - Smithing
   - Sailing (Salvaging)
+  - Hunter (Maniacal Monkeys)
 - Customizable overlay color and opacity
 - Customizable restore delay
 - Individual toggles for each supported skill
@@ -28,7 +29,7 @@ https://github.com/user-attachments/assets/3c1d7267-9103-41e2-9f6a-79cfa498e330
 - Brief delay before activation to prevent flickering during short pauses
 
 ## How It Works
-1. The plugin detects when you're performing a supported skilling activity by monitoring your character's animation.
+1. The plugin detects when you're performing a supported skilling activity by monitoring your character's animation or position.
 2. If the corresponding skill toggle is enabled, the overlay will activate after a short delay (to prevent flickering during brief pauses).
 3. The overlay will disappear shortly after you stop the skilling activity or become idle for more than 2 game ticks.
 

--- a/src/main/java/com/distractionreducer/DistractionReducerConfig.java
+++ b/src/main/java/com/distractionreducer/DistractionReducerConfig.java
@@ -149,6 +149,14 @@ public interface DistractionReducerConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "hunterManiacalMonkeys",
+            name = "Hunter (Maniacal Monkeys)",
+            description = "Display overlay while trapping maniacal monkeys",
+            section = skillingToggles
+    )
+    default boolean hunterManiacalMonkeys() { return true; }
+
     @Alpha
     @ConfigItem(
             keyName = "overlayColor",

--- a/src/main/java/com/distractionreducer/DistractionReducerPlugin.java
+++ b/src/main/java/com/distractionreducer/DistractionReducerPlugin.java
@@ -3,7 +3,8 @@ package com.distractionreducer;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 import net.runelite.api.*;
-import net.runelite.api.coords.WorldPoint;  // Add this import
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.coords.WorldArea;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.events.GameStateChanged;
@@ -22,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @PluginDescriptor(
         name = "Distraction Reducer",
         description = "Blacks out the screen while skilling to reduce distractions",
-        tags = {"woodcutting", "fishing", "mining", "cooking", "herblore", "crafting", "fletching", "smithing", "magic", "sailing", "salvaging", "skilling", "overlay"}
+        tags = { "woodcutting", "fishing", "mining", "cooking", "herblore", "crafting", "fletching", "smithing", "magic", "sailing", "salvaging", "hunter", "skilling", "overlay" }
 )
 @Slf4j
 public class DistractionReducerPlugin extends Plugin {
@@ -72,6 +73,30 @@ public class DistractionReducerPlugin extends Plugin {
 
     // Duke Sucellus Region ID
     private static final int DUKE_SUCELLUS_REGION = 12132;
+
+    //region Kruk's Dungeon (Maniacal Monkeys)
+    private static final int KRUKS_DUNGEON_REGION = 11662;
+    private static final Set<Integer> MONKEYTRAP_ACTIVE_OBJECT_IDS = Set.of(
+            net.runelite.api.gameval.ObjectID.HUNTING_MONKEYTRAP_SETTING,    // 28825 - trap being set up
+            net.runelite.api.gameval.ObjectID.HUNTING_MONKEYTRAP_SET,        // 28827 - trap set and waiting
+            net.runelite.api.gameval.ObjectID.HUNTING_MONKEYTRAP_TRAPPING_0, // 28828 - monkey triggering trap
+            net.runelite.api.gameval.ObjectID.HUNTING_MONKEYTRAP_TRAPPING_1  // 28829 - monkey triggering trap
+    );
+
+    /**
+     * Relative tile offsets where a maniacal monkey trap GameObject may exist
+     * relative to the player when hunting in Kruk's Dungeon.
+     * Maniacal monkey traps are placed exactly two tiles away from the player in
+     * one of the four cardinal/adjacent directions.
+     */
+    private static final int[][] MANIACAL_MONKEY_TRAP_OFFSETS =
+    {
+            {2, 0},
+            {-2, 0},
+            {0, 2},
+            {0, -2}
+    };
+    //endregion
 
     // POH Region IDs - Player-Owned Houses are instanced and use specific region ranges
     private static final Set<Integer> POH_REGIONS = Set.of(
@@ -313,6 +338,68 @@ public class DistractionReducerPlugin extends Plugin {
         updateOverlayVisibility();
     }
 
+    /**
+     * Returns true if the player is hunting maniacal monkeys.
+     * Detects this by checking the four tiles exactly two spaces away from the
+     * player (N/S/E/W) for an active monkey trap object in Kruk's Dungeon.
+     */
+    private boolean isHuntingManiacalMonkeys()
+    {
+        final Player player = client.getLocalPlayer();
+        if (player == null)
+        {
+            return false;
+        }
+
+        final WorldPoint worldPoint = player.getWorldLocation();
+        if (worldPoint == null || worldPoint.getRegionID() != KRUKS_DUNGEON_REGION)
+        {
+            return false;
+        }
+
+        final LocalPoint localPoint = player.getLocalLocation();
+        if (localPoint == null)
+        {
+            return false;
+        }
+
+        final int plane = worldPoint.getPlane();
+        final int sceneX = localPoint.getSceneX();
+        final int sceneY = localPoint.getSceneY();
+        final Tile[][][] tiles = player.getWorldView().getScene().getTiles();
+
+        // Check two tiles adjacent to the player in any direction for rock traps (4 possible spots)
+        for (int[] offset : MANIACAL_MONKEY_TRAP_OFFSETS)
+        {
+            final int x = sceneX + offset[0];
+            final int y = sceneY + offset[1];
+
+            // Make sure we're not checking out of the scene's bounds
+            if (x < 0 || y < 0 || x >= Constants.SCENE_SIZE || y >= Constants.SCENE_SIZE)
+            {
+                continue;
+            }
+
+            final Tile tile = tiles[plane][x][y];
+            if (tile == null)
+            {
+                continue;
+            }
+
+            // If there's a rock object next to the player...
+            for (GameObject obj : tile.getGameObjects())
+            {
+                // Check if a trap has been set on it
+                if (obj != null && MONKEYTRAP_ACTIVE_OBJECT_IDS.contains(obj.getId()))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private boolean isPlayerMoving(Player player) {
         int poseAnimation = player.getPoseAnimation();
 
@@ -410,7 +497,8 @@ public class DistractionReducerPlugin extends Plugin {
                 (FIREMAKING_ANIMATION_IDS.contains(animation) && config.firemaking()) ||
                 (SAILING_SALVAGING_ANIMATION_IDS.contains(animation) && config.sailing()) ||
                 (isSmithing(animation) && config.smithing()) ||
-                (isMagic(animation) && config.magic());
+                (isMagic(animation) && config.magic()) ||
+                (isHuntingManiacalMonkeys() && config.hunterManiacalMonkeys());
     }
 
     private boolean isInToaBank() {


### PR DESCRIPTION
Adds support for detecting maniacal monkey hunting in Kruk's Dungeon.

This change involves looking at Game Objects instead of animations, since this hunting activity involves the player being idle most of the time.

The plugin checks the four tiles two spaces away from the player (N/S/E/W) for active monkey trap objects. If found, the activity is treated as maniacal monkey hunting and the distraction overlay is enabled.

Because this detection relies on scene objects, the overlay could theoretically trigger if the player stands next to another player’s trap. In practice this should not occur, since traps cannot be shared between players.

The check is limited to the Kruk's Dungeon region, so performance impact is negligible.

Demo:

https://github.com/user-attachments/assets/e4631c68-d7c9-4e73-9530-3e1df384b597


