### PR TITLE
Added Trailblazer + Trailblazer Reloaded axes to trigger overlay

### DIFF
--- a/src/main/java/com/distractionreducer/DistractionReducerPlugin.java
+++ b/src/main/java/com/distractionreducer/DistractionReducerPlugin.java
@@ -174,7 +174,10 @@ public class DistractionReducerPlugin extends Plugin {
             AnimationID.WOODCUTTING_TRAILBLAZER, AnimationID.WOODCUTTING_2H_BRONZE, AnimationID.WOODCUTTING_2H_IRON,
             AnimationID.WOODCUTTING_2H_STEEL, AnimationID.WOODCUTTING_2H_BLACK, AnimationID.WOODCUTTING_2H_MITHRIL,
             AnimationID.WOODCUTTING_2H_ADAMANT, AnimationID.WOODCUTTING_2H_RUNE, AnimationID.WOODCUTTING_2H_DRAGON,
-            AnimationID.WOODCUTTING_2H_CRYSTAL, AnimationID.WOODCUTTING_2H_CRYSTAL_INACTIVE, AnimationID.WOODCUTTING_2H_3A
+            AnimationID.WOODCUTTING_2H_CRYSTAL, AnimationID.WOODCUTTING_2H_CRYSTAL_INACTIVE, AnimationID.WOODCUTTING_2H_3A,
+            net.runelite.api.gameval.AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_AXE,
+            net.runelite.api.gameval.AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_RELOADED_AXE,
+            net.runelite.api.gameval.AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_RELOADED_AXE_NO_INFERNAL
     );
 
     private static final Set<Integer> SMITHING_ANIMATION_IDS = Set.of(


### PR DESCRIPTION
## Prior behaviour
`Dragon axe (or)` (specifically the Trailblazer Reloaded variant), and `Infernal axe (or)` (both the Trailblazer and Trailblazer Reloaded variants) were not triggering the distraction overlay when woodcutting.

<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/203ec9a0-b199-46da-988b-2213eec60bc6" />
<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/de3f035d-83fb-4376-893a-4c6ec2d8bb0f" />
<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/b62c0c08-5917-46ee-ac2c-7baefa8a05d0" />
<br><br>

`Dragon axe (or)`, the normal Trailblazer variant shares the same `AnimationID` as `AnimationID.WOODCUTTING_DRAGON_OR`, so that functionality already worked as expected.

<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/2b47b585-b478-4a26-b0d1-c3268b067292" />


## Fixed behaviour
All Trailblazer axe variants now trigger the distraction overlay as intended.

<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/302580f9-307d-44b7-af1a-aa6413ee4d91" />
<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/7fdf6dd7-ef9d-4cdc-8fe2-3a09a7564cd2" />
<img width="448" height="250" alt="image" src="https://github.com/user-attachments/assets/a5643f49-1098-49ea-a52e-b09e60c9b7bd" />

## Code Review Comments
It's just adding a few IDs to a set, however I've followed the style referencing the path elsewhere in the file referring to `net.runelite.api.gameval`; done this way since `AnimationID` from `net.runelite.api` has been deprecated.